### PR TITLE
Bugs/stream.flow

### DIFF
--- a/lib/protocol/connection.js
+++ b/lib/protocol/connection.js
@@ -189,7 +189,6 @@ Connection.prototype._allocateId = function _allocateId(stream, id) {
   this._log.trace({ s: stream, stream_id: id }, 'Allocating ID for stream.');
   this._streamIds[id] = stream;
   stream.id = id;
-  this.emit('new_stream', stream, id);
 
   // * forwarding connection errors from streams
   stream.on('connectionError', this.emit.bind(this, 'error'));
@@ -246,6 +245,7 @@ Connection.prototype.createStream = function createStream() {
   // * Receiving is enabled immediately, and an ID gets assigned to the stream
   var stream = new Stream(this._log, this);
   this._allocatePriority(stream);
+  this.emit('new_stream', stream);
 
   return stream;
 };

--- a/lib/protocol/flow.js
+++ b/lib/protocol/flow.js
@@ -350,5 +350,5 @@ Flow.prototype._updateWindow = function _updateWindow(frame) {
 Flow.prototype.setInitialWindow = function setInitialWindow(initialWindow) {
   this._increaseWindow(initialWindow - this._initialWindow);
   this._initialWindow = initialWindow;
-  this._log.trace('JITU Increasing flow control window size.' + this._initialWindow);
+  this._log.trace('JITU Increasing flow control window size.');
 };

--- a/lib/protocol/flow.js
+++ b/lib/protocol/flow.js
@@ -351,5 +351,4 @@ Flow.prototype._updateWindow = function _updateWindow(frame) {
 Flow.prototype.setInitialWindow = function setInitialWindow(initialWindow) {
   this._increaseWindow(initialWindow - this._initialWindow);
   this._initialWindow = initialWindow;
-  this._log.trace('JITU Increasing flow control window size.');
 };

--- a/lib/protocol/flow.js
+++ b/lib/protocol/flow.js
@@ -350,4 +350,5 @@ Flow.prototype._updateWindow = function _updateWindow(frame) {
 Flow.prototype.setInitialWindow = function setInitialWindow(initialWindow) {
   this._increaseWindow(initialWindow - this._initialWindow);
   this._initialWindow = initialWindow;
+  this._log.trace('JITU Increasing flow control window size.' + this._initialWindow);
 };


### PR DESCRIPTION
SETTINGS frame may update SETTINGS_INITIAL_WINDOW_SIZE that affects
new stream window. For example, if SETTINGS_INITIAL_WINDOW_SIZE = 0,
initial DATA frames for new streams were going through to the peer
even though there is no stream window.

The fix is to adjust initial stream window for the newly created
streams.

```
Looks like `_allocateId` is deferred until first stream usage to make sure new stream ids are ordered correctly, but that was too late to properly honor the server-specified initial stream window negotiated during `SETTINGS` handshake.

Moving the notification of new stream earlier to pick up the server-specified initial stream window looks good to me.
```