### PR TITLE
Trigger error on pako inflate frame failure with inflate status

### DIFF
--- a/lib/protocol/stream.js
+++ b/lib/protocol/stream.js
@@ -274,6 +274,16 @@ Stream.prototype._writeUpstream = function _writeUpstream(frame) {
   return moreNeeded;
 };
 
+var inflateStatusToName = {
+  "0": "Z_OK",
+  "1": "Z_STREAM_END",
+  "2": "Z_SYNC_FLUSH",
+  "-1": "ERRNO",
+  "-2": "STREAM_ERROR",
+  "-3": "DATA_ERROR",
+  "-4": "MEM_ERROR" 
+};
+
 // The `_receive` method (= `upstream._receive`) gets called when there's an incoming frame.
 Stream.prototype._receive = function _receive(frame, ready) {
   // * If it's a DATA frame, then push the payload into the output buffer on the other side.
@@ -296,6 +306,14 @@ Stream.prototype._receive = function _receive(frame, ready) {
       }
       var data = frame.data;
       this.pakoInf.push(data, frame.END_STREAM);
+
+      if (this.pakoInf.err < 0) {  
+        var statusName = inflateStatusToName[this.pakoInf.err];
+        var inflateError = new Error('Inflate frame failed with status ' + statusName); 
+        this._log.error(inflateError, inflateError.message);
+        this.reset(inflateError);
+        this.emit('error', inflateError);
+      }
     }
     else
     {


### PR DESCRIPTION
Trigger error on inflating data failure, but still, need works to continue to receive new request gracefully for consecutive requests to works.

See Pako error handling reference:
- https://nodeca.github.io/pako/#Inflate.new

<img width="1195" alt="screen shot 2018-02-06 at 11 02 10 am" src="https://user-images.githubusercontent.com/8635/35878465-36f77c06-0b2d-11e8-9b7c-f7b5b6fd4b57.png">
