### PR TITLE
Features/retry-after

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ point to understand the code.
 ### Test coverage ###
 
 To generate a code coverage report, run `npm test --coverage` (which runs very slowly, be patient).
-Code coverage summary as of version 3.0.1:
+Code coverage summary as of version 4.0.2:
 ```
-Statements   : 89.47% ( 1980/2213 )
-Branches     : 79.03% ( 829/1049 )
-Functions    : 89.27% ( 233/261 )
-Lines        : 89.61% ( 1974/2203 )
+Statements   : 89.41% ( 2018/2257 )
+Branches     : 78.92% ( 846/1072 )
+Functions    : 89.47% ( 238/266 )
+Lines        : 89.54% ( 2012/2247 )
 ```
 
 There's a hosted version of the detailed (line-by-line) coverage report

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ point to understand the code.
 To generate a code coverage report, run `npm test --coverage` (which runs very slowly, be patient).
 Code coverage summary as of version 4.0.2:
 ```
-Statements   : 89.41% ( 2018/2257 )
-Branches     : 78.92% ( 846/1072 )
+Statements   : 89.41% ( 2017/2256 )
+Branches     : 78.96% ( 848/1074 )
 Functions    : 89.47% ( 238/266 )
-Lines        : 89.54% ( 2012/2247 )
+Lines        : 89.54% ( 2011/2246 )
 ```
 
 There's a hosted version of the detailed (line-by-line) coverage report

--- a/lib/http.js
+++ b/lib/http.js
@@ -1370,7 +1370,7 @@ function parseRetryAfter(retryAfter) {
     if (typeof retryAfter === 'number') {
         return retryAfter;
     } else if (isNaN(retryAfter)) {
-      return Math.round((new Date(retryAfter).getTime() - Date.now()) / 1000);
+      return Math.ceil((new Date(retryAfter).getTime() / 1000) - Date.now() / 1000);
     } else {
       return parseInt(retryAfter, 10); 
     }
@@ -1412,8 +1412,10 @@ IncomingResponse.prototype._onHeaders = function _onHeaders(headers) {
     // * Signaling that the headers arrived.
     self._log.info({ status: self.statusCode, headers: self.headers}, 'Incoming response with retry-after delay:' + retryAfterDelay);
 
-    self.req._retryAfter(retryAfterDelay);
-    return; 
+    if (retryAfterDelay > 0) {
+      self.req._retryAfter(retryAfterDelay); 
+      return;
+    } 
   }
   
   // * Handling regular headers.

--- a/lib/http.js
+++ b/lib/http.js
@@ -1224,12 +1224,14 @@ OutgoingRequest.prototype._retryAfter = function _retryAfter(retryAfterDelay) {
 
   this._retryAfterAttempt = this._retryAfterAttempt ? this._retryAfterAttempt++ : 1;
 
-  // retryAfterDelayMs = max(retryAfter, random_between(0, min(cap, base * 2 ** attempt)))
+  // Exponential backoff based on attempts:
+  // retryAfterDelayMs = max(retryAfter, random_between(0, min(cap, base * 2 ** attempt))) 
+  // attempt intervals based on expression above and retryAfter = 0: [800,1600,3200,...30000]
   retryAfterDelayMs = Math.max(retryAfterDelayMs, 
       randomIntFromInterval(0, Math.min(
-          this._retryAfterCap, 
-          Math.pow(this._retryAfterBase, this._retryAfterAttempt))
-      )
+          this._retryAfterCap,
+          this._retryAfterBase * Math.pow(2, this._retryAfterAttempt) 
+      ))
   );
   
   // Schedule request retry

--- a/lib/http.js
+++ b/lib/http.js
@@ -1230,6 +1230,7 @@ OutgoingRequest.prototype._retryAfter = function _retryAfter(retryAfterDelay) {
       randomIntFromInterval(0, Math.min(
           this._retryAfterCap, 
           retryAfterDelayMs + (this._retryAfterBase * this._retryAfterAttempt))
+          //retryAfterDelayMs + Math.pow(this._retryAfterBase, this._retryAfterAttempt))
       )
   );
   

--- a/lib/http.js
+++ b/lib/http.js
@@ -1412,10 +1412,8 @@ IncomingResponse.prototype._onHeaders = function _onHeaders(headers) {
     // * Signaling that the headers arrived.
     self._log.info({ status: self.statusCode, headers: self.headers}, 'Incoming response with retry-after delay:' + retryAfterDelay);
 
-    if (retryAfterDelay > 0) {
-      self.req._retryAfter(retryAfterDelay); 
-      return;
-    } 
+    self.req._retryAfter(retryAfterDelay); 
+    return;
   }
   
   // * Handling regular headers.

--- a/lib/http.js
+++ b/lib/http.js
@@ -991,7 +991,6 @@ Agent.prototype.request = function request(options, callback) {
   }
 
   // Re-use transportUrl endPoint if specified
-  var key;
   if (options.transportUrl && options.transport) {
     key = ([
         options.transportUrl
@@ -1009,7 +1008,7 @@ Agent.prototype.request = function request(options, callback) {
   // * There's an existing HTTP/2 connection to this host
   if (key in this.endpoints && this.endpoints[key]) {
     endpoint = this.endpoints[key];
-    request._start(endpoint.createStream(), options);
+    request._start(endpoint.createStream(), options, endpoint);
   }
 
   // * HTTP/2 over generic stream transport
@@ -1033,7 +1032,7 @@ Agent.prototype.request = function request(options, callback) {
 
     this.endpoints[key] = endpoint;
     endpoint.pipe(endpoint.socket).pipe(endpoint);
-    request._start(endpoint.createStream(), options);
+    request._start(endpoint.createStream(), options, endpoint);
 }
   // * HTTP/2 over plain TCP
       // TODO deprecate?
@@ -1057,7 +1056,7 @@ Agent.prototype.request = function request(options, callback) {
 
     this.endpoints[key] = endpoint;
     endpoint.pipe(endpoint.socket).pipe(endpoint);
-    request._start(endpoint.createStream(), options);
+    request._start(endpoint.createStream(), options, endpoint);
   }
 
   // * HTTP/2 over TLS negotiated using NPN or ALPN, or fallback to HTTPS1
@@ -1122,13 +1121,13 @@ Agent.prototype.request = function request(options, callback) {
     this.once(key, function(endpoint) {
       started = true;
       if (endpoint) {
-        request._start(endpoint.createStream(), options);
+        request._start(endpoint.createStream(), options, endpoint);
       } else {
         request._fallback(httpsRequest);
       }
     });
   }
-
+  
   return request;
 };
 
@@ -1161,7 +1160,7 @@ function unbundleSocket(socket) {
 }
 
 function hasValue(obj) {
-  return obj != null;
+  return obj !== null && obj !== undefined;
 }
 
 
@@ -1199,9 +1198,23 @@ function OutgoingRequest() {
 }
 OutgoingRequest.prototype = Object.create(OutgoingMessage.prototype, { constructor: { value: OutgoingRequest } });
 
-OutgoingRequest.prototype._start = function _start(stream, options) {
+OutgoingRequest.prototype._retry = function _retry() {
+  var options = this.options,
+      endpoint = this.endpoint,
+      newStream = endpoint.createStream();
+
+  // Clear state
+  this._headers = {};
+  this.headersSent = false;
+
+  // Restart OutgoingRequest
+  this._start(newStream, options, endpoint);
+};
+
+OutgoingRequest.prototype._start = function _start(stream, options, endpoint) {
   this.stream = stream;
   this.options = options;
+  this.endpoint = endpoint;
 
   this._log = stream._log.child({ component: 'http' });
 
@@ -1210,6 +1223,7 @@ OutgoingRequest.prototype._start = function _start(stream, options) {
       this.setHeader(headerName, options.headers[headerName]);
     }
   }
+
   var headers = this._headers;
   delete headers.host;
 
@@ -1330,7 +1344,59 @@ IncomingResponse.prototype = Object.create(IncomingMessage.prototype, { construc
 // * `headers` argument: HTTP/2.0 request and response header fields carry information as a series
 //   of key-value pairs. This includes the target URI for the request, the status code for the
 //   response, as well as HTTP header fields.
+
+IncomingResponse.prototype.retryAfterStatusCodes = ['503', '302', '429'];
+IncomingResponse.prototype.retryAfterTimer = null;
+
+// Parse retry-after header delay to get next request retry attempt date in seconds
+// * "Fri, 31 Dec 2018 23:59:59 GMT"
+//   "Thu Jul 12 2018 12:53:16 GMT-0700 (Pacific Daylight Time)"
+//   "120"
+function parseRetryAfter(retryAfter) {
+    // Only parse once
+    if (typeof retryAfter === 'number') {
+        return retryAfter;
+    } else if (isNaN(retryAfter)) {
+      return (new Date(retryAfter).getTime() - Date.now()) / 1000;
+    } else {
+      return parseInt(retryAfter, 10); 
+    }
+}
+
 IncomingResponse.prototype._onHeaders = function _onHeaders(headers) {
+
+  var self = this;
+  
+  // TODO get other IncomingResponse that should share retryAfter directive to
+  // catch others request emited after this request IncomingResponse got locked in retryAfter.
+  
+  // DEBUG:
+  //console.log('_onHeaders', headers[':status'], headers['retry-after']);
+
+  // If a Retry-After header ([RFC2616]) is present in the response, the client SHOULD<6> retry the 
+  // request after waiting the number of seconds indicated by the Retry-After header. Any such value 
+  // represents an estimate of when the server is expected to be able to process the request.
+  if (
+    self.retryAfterStatusCodes.indexOf(headers[':status']) !== -1 && // Match retry-after StatusCodes
+      headers.hasOwnProperty('retry-after') && headers['retry-after'] // Has retry-after and is not empty
+  ) {
+
+    // TODO extract retryAfterDelay from retry-after header value
+    var retryAfterDelay = parseRetryAfter(headers['retry-after']),
+        retryAfterDelayMs = retryAfterDelay * 1000;
+
+    //console.log(retryAfterDelayMs);
+
+    // Clear previous timer in case _onHeaders get re-trigger
+    clearTimeout(self.retryAfterTimer);
+
+    // Schedule request retry
+    self.retryAfterTimer = setTimeout(function () {
+      self.req._retry();
+    }, retryAfterDelayMs);
+    return; 
+  }
+
   // * A single ":status" header field is defined that carries the HTTP status code field. This
   //   header field MUST be included in all responses.
   // * A client MUST treat the absence of the ":status" header field, the presence of multiple
@@ -1338,22 +1404,18 @@ IncomingResponse.prototype._onHeaders = function _onHeaders(headers) {
   //   Note: currently, we do not enforce it strictly: we accept any format, and parse it as int
   // * HTTP/2.0 does not define a way to carry the reason phrase that is included in an HTTP/1.1
   //   status line.
-  this.statusCode = parseInt(this._checkSpecialHeader(':status', headers[':status']));
-
-  // If a Retry-After header ([RFC2616]) is present in the response, the client SHOULD<6> retry the 
-  // request after waiting the number of seconds indicated by the Retry-After header. Any such value 
-  // represents an estimate of when the server is expected to be able to process the request.
+  self.statusCode = parseInt(self._checkSpecialHeader(':status', headers[':status']));
 
   // TODO detect headers['retry-after'] and statusCode 503|429|302
   // TODO if has retry-after pause IncomingMessage and schedule retry
   // TODO cancel retry on window onunload event? 
-
+  
   // * Handling regular headers.
-  IncomingMessage.prototype._onHeaders.call(this, headers);
+  IncomingMessage.prototype._onHeaders.call(self, headers);
 
   // * Signaling that the headers arrived.
-  this._log.info({ status: this.statusCode, headers: this.headers}, 'Incoming response');
-  this.emit('ready');
+  self._log.info({ status: self.statusCode, headers: self.headers}, 'Incoming response');
+  self.emit('ready');
 };
 
 IncomingResponse.prototype.getHeader = function getHeader(name) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -303,6 +303,7 @@ IncomingMessage.prototype = Object.create(PassThrough.prototype, { constructor: 
 //   of key-value pairs. This includes the target URI for the request, the status code for the
 //   response, as well as HTTP header fields.
 IncomingMessage.prototype._onHeaders = function _onHeaders(headers) {
+
   // * Detects malformed headers
   this._validateHeaders(headers);
 
@@ -1339,12 +1340,24 @@ IncomingResponse.prototype._onHeaders = function _onHeaders(headers) {
   //   status line.
   this.statusCode = parseInt(this._checkSpecialHeader(':status', headers[':status']));
 
+  // If a Retry-After header ([RFC2616]) is present in the response, the client SHOULD<6> retry the 
+  // request after waiting the number of seconds indicated by the Retry-After header. Any such value 
+  // represents an estimate of when the server is expected to be able to process the request.
+
+  // TODO detect headers['retry-after'] and statusCode 503|429|302
+  // TODO if has retry-after pause IncomingMessage and schedule retry
+  // TODO cancel retry on window onunload event? 
+
   // * Handling regular headers.
   IncomingMessage.prototype._onHeaders.call(this, headers);
 
   // * Signaling that the headers arrived.
   this._log.info({ status: this.statusCode, headers: this.headers}, 'Incoming response');
   this.emit('ready');
+};
+
+IncomingResponse.prototype.getHeader = function getHeader(name) {
+  return this.headers[name.toLowerCase()];
 };
 
 // IncomingPromise class

--- a/lib/http.js
+++ b/lib/http.js
@@ -1196,19 +1196,29 @@ function OutgoingRequest() {
 
   this.stream = undefined;
 }
+
 OutgoingRequest.prototype = Object.create(OutgoingMessage.prototype, { constructor: { value: OutgoingRequest } });
 
-OutgoingRequest.prototype._retry = function _retry() {
+OutgoingRequest.prototype._retryAfterTimer = null;
+
+OutgoingRequest.prototype._retryAfter = function _retryAfter(retryAfterDelay) {
+
   var options = this.options,
       endpoint = this.endpoint,
-      newStream = endpoint.createStream();
+      newStream = endpoint.createStream(),
+      retryAfterDelayMs = retryAfterDelay * 1000;
 
-  // Clear state
+  // Clear request state
   this._headers = {};
   this.headersSent = false;
 
-  // Restart OutgoingRequest
-  this._start(newStream, options, endpoint);
+  // Clear previous request retry
+  clearTimeout(this._retryAfterTimer);
+  
+  // Schedule request retry
+  // TODO cancel retry on window onunload event?
+  // Note: has clearTimeout on Aborting
+  this._retryAfterTimer = setTimeout(this._start.bind(this, newStream, options, endpoint), retryAfterDelayMs);
 };
 
 OutgoingRequest.prototype._start = function _start(stream, options, endpoint) {
@@ -1310,6 +1320,10 @@ OutgoingRequest.prototype.setTimeout = function setTimeout(timeout, callback) {
 
 // Aborting the request
 OutgoingRequest.prototype.abort = function abort() {
+  
+  // Clear retry on abort
+  clearTimeout(this._retryAfterTimer);
+
   if (this.request) {
     this.request.abort();
   } else if (this.stream) {
@@ -1345,8 +1359,7 @@ IncomingResponse.prototype = Object.create(IncomingMessage.prototype, { construc
 //   of key-value pairs. This includes the target URI for the request, the status code for the
 //   response, as well as HTTP header fields.
 
-IncomingResponse.prototype.retryAfterStatusCodes = ['503', '302', '429'];
-IncomingResponse.prototype.retryAfterTimer = null;
+IncomingResponse.prototype.retryAfterStatusCodes = [503, 302, 429];
 
 // Parse retry-after header delay to get next request retry attempt date in seconds
 // * "Fri, 31 Dec 2018 23:59:59 GMT"
@@ -1357,7 +1370,7 @@ function parseRetryAfter(retryAfter) {
     if (typeof retryAfter === 'number') {
         return retryAfter;
     } else if (isNaN(retryAfter)) {
-      return (new Date(retryAfter).getTime() - Date.now()) / 1000;
+      return Math.round((new Date(retryAfter).getTime() - Date.now()) / 1000);
     } else {
       return parseInt(retryAfter, 10); 
     }
@@ -1366,6 +1379,15 @@ function parseRetryAfter(retryAfter) {
 IncomingResponse.prototype._onHeaders = function _onHeaders(headers) {
 
   var self = this;
+
+  // * A single ":status" header field is defined that carries the HTTP status code field. This
+  //   header field MUST be included in all responses.
+  // * A client MUST treat the absence of the ":status" header field, the presence of multiple
+  //   values, or an invalid value as a stream error of type PROTOCOL_ERROR.
+  //   Note: currently, we do not enforce it strictly: we accept any format, and parse it as int
+  // * HTTP/2.0 does not define a way to carry the reason phrase that is included in an HTTP/1.1
+  //   status line.
+  self.statusCode = parseInt(self._checkSpecialHeader(':status', headers[':status']));
   
   // TODO get other IncomingResponse that should share retryAfter directive to
   // catch others request emited after this request IncomingResponse got locked in retryAfter.
@@ -1377,38 +1399,22 @@ IncomingResponse.prototype._onHeaders = function _onHeaders(headers) {
   // request after waiting the number of seconds indicated by the Retry-After header. Any such value 
   // represents an estimate of when the server is expected to be able to process the request.
   if (
-    self.retryAfterStatusCodes.indexOf(headers[':status']) !== -1 && // Match retry-after StatusCodes
+    self.retryAfterStatusCodes.indexOf(self.statusCode) !== -1 && // Match retry-after StatusCodes
       headers.hasOwnProperty('retry-after') && headers['retry-after'] // Has retry-after and is not empty
   ) {
 
-    // TODO extract retryAfterDelay from retry-after header value
-    var retryAfterDelay = parseRetryAfter(headers['retry-after']),
-        retryAfterDelayMs = retryAfterDelay * 1000;
+    // Extract retryAfterDelay from retry-after header value in seconds
+    var retryAfterDelay = parseRetryAfter(headers['retry-after']);
 
-    //console.log(retryAfterDelayMs);
+    // DEBUG:
+    //console.log('Incoming response with retry-after delay:' + retryAfterDelay);
+    
+    // * Signaling that the headers arrived.
+    self._log.info({ status: self.statusCode, headers: self.headers}, 'Incoming response with retry-after delay:' + retryAfterDelay);
 
-    // Clear previous timer in case _onHeaders get re-trigger
-    clearTimeout(self.retryAfterTimer);
-
-    // Schedule request retry
-    self.retryAfterTimer = setTimeout(function () {
-      self.req._retry();
-    }, retryAfterDelayMs);
+    self.req._retryAfter(retryAfterDelay);
     return; 
   }
-
-  // * A single ":status" header field is defined that carries the HTTP status code field. This
-  //   header field MUST be included in all responses.
-  // * A client MUST treat the absence of the ":status" header field, the presence of multiple
-  //   values, or an invalid value as a stream error of type PROTOCOL_ERROR.
-  //   Note: currently, we do not enforce it strictly: we accept any format, and parse it as int
-  // * HTTP/2.0 does not define a way to carry the reason phrase that is included in an HTTP/1.1
-  //   status line.
-  self.statusCode = parseInt(self._checkSpecialHeader(':status', headers[':status']));
-
-  // TODO detect headers['retry-after'] and statusCode 503|429|302
-  // TODO if has retry-after pause IncomingMessage and schedule retry
-  // TODO cancel retry on window onunload event? 
   
   // * Handling regular headers.
   IncomingMessage.prototype._onHeaders.call(self, headers);

--- a/lib/http.js
+++ b/lib/http.js
@@ -693,6 +693,7 @@ exports.https = {};
 exports.createServer = exports.https.createServer = createServerTLS;
 exports.request = exports.https.request = requestTLS;
 exports.get = exports.https.get = getTLS;
+exports.post = exports.https.post = postTLS;
 
 // Exposed main interfaces for raw TCP connections (not recommended)
 exports.raw = {};
@@ -938,6 +939,22 @@ function getTLS(options, callback) {
   return exports.globalAgent.get(options, callback);
 }
 
+function postTLS(options, body, callback) {
+  if (typeof options === "string") {
+    options = url.parse(options);
+  }
+  options.plain = false;
+  if (options.protocol && options.protocol !== "https:") {
+    throw new Error('This interface only supports https-schemed URLs');
+  }
+  if (options.agent && typeof(options.agent.get) === 'function') {
+    var agentOptions = assign({}, options);
+    delete agentOptions.agent;
+    return options.agent.post(agentOptions, body, callback);
+  }
+  return exports.globalAgent.post(options, body, callback);
+}
+
 // Agent class
 // -----------
 
@@ -1134,6 +1151,12 @@ Agent.prototype.request = function request(options, callback) {
 Agent.prototype.get = function get(options, callback) {
   var request = this.request(options, callback);
   request.end();
+  return request;
+};
+
+Agent.prototype.post = function get(options, body, callback) {
+  var request = this.request(options, callback);
+  request.end(body);
   return request;
 };
 
@@ -1441,10 +1464,6 @@ IncomingResponse.prototype._onHeaders = function _onHeaders(headers) {
   // * Signaling that the headers arrived.
   self._log.info({ status: self.statusCode, headers: self.headers}, 'Incoming response');
   self.emit('ready');
-};
-
-IncomingResponse.prototype.getHeader = function getHeader(name) {
-  return this.headers[name.toLowerCase()];
 };
 
 // IncomingPromise class

--- a/lib/http.js
+++ b/lib/http.js
@@ -1200,6 +1200,13 @@ function OutgoingRequest() {
 OutgoingRequest.prototype = Object.create(OutgoingMessage.prototype, { constructor: { value: OutgoingRequest } });
 
 OutgoingRequest.prototype._retryAfterTimer = null;
+OutgoingRequest.prototype._retryAfterBase = 200;
+OutgoingRequest.prototype._retryAfterCap = 30000;
+OutgoingRequest.prototype._retryAfterAttempt = null;
+
+function randomIntFromInterval(min, max) {
+    return Math.floor(Math.random() * (max - min + 1) + min);
+}
 
 OutgoingRequest.prototype._retryAfter = function _retryAfter(retryAfterDelay) {
 
@@ -1214,6 +1221,17 @@ OutgoingRequest.prototype._retryAfter = function _retryAfter(retryAfterDelay) {
 
   // Clear previous request retry
   clearTimeout(this._retryAfterTimer);
+
+  this._retryAfterAttempt = this._retryAfterAttempt ? this._retryAfterAttempt++ : 1;
+
+  // CURRENT:  max(retryAfter, random_between(0, min(cap, retryAfter + base * attempt)))
+  // SHOULD BE ? max(retryAfter, random_between(0, min(cap, base * 2 ** attempt)))
+  retryAfterDelayMs = Math.max(retryAfterDelayMs, 
+      randomIntFromInterval(0, Math.min(
+          this._retryAfterCap, 
+          retryAfterDelayMs + (this._retryAfterBase * this._retryAfterAttempt))
+      )
+  );
   
   // Schedule request retry
   // TODO cancel retry on window onunload event?

--- a/lib/http.js
+++ b/lib/http.js
@@ -1229,8 +1229,8 @@ OutgoingRequest.prototype._retryAfter = function _retryAfter(retryAfterDelay) {
   retryAfterDelayMs = Math.max(retryAfterDelayMs, 
       randomIntFromInterval(0, Math.min(
           this._retryAfterCap, 
-          retryAfterDelayMs + (this._retryAfterBase * this._retryAfterAttempt))
-          //retryAfterDelayMs + Math.pow(this._retryAfterBase, this._retryAfterAttempt))
+          (this._retryAfterBase * this._retryAfterAttempt))
+          //Math.pow(this._retryAfterBase, this._retryAfterAttempt))
       )
   );
   

--- a/lib/http.js
+++ b/lib/http.js
@@ -137,7 +137,6 @@ var protocol = require('./protocol');
 var Endpoint = protocol.Endpoint;
 var https = require('https');
 var assign = Object.assign || require('object.assign');
-var pako = require('pako');
 
 exports.STATUS_CODES = {
     '202': 'Accepted',
@@ -1285,17 +1284,18 @@ OutgoingRequest.prototype._start = function _start(stream, options, endpoint) {
 
   headers[':scheme'] = options.protocol.slice(0, -1);
   headers[':method'] = options.method;
+  headers[':path'] = options.path;
+
   if (options.port) {
       headers[':authority'] = options.host + ':' + options.port;
   } else {
       headers[':authority'] = options.host;
   }
-
-  if (!headers['accept-encoding']) // The app expects to handle the encoding
-  {
+  
+  // The app expects to handle the encoding
+  if (!headers['accept-encoding']) {
       headers['accept-encoding'] = 'gzip';
   }
-  headers[':path'] = options.path;
 
   this._log.info({ scheme: headers[':scheme'], method: headers[':method'],
                    authority: headers[':authority'], path: headers[':path'],

--- a/lib/http.js
+++ b/lib/http.js
@@ -1224,13 +1224,11 @@ OutgoingRequest.prototype._retryAfter = function _retryAfter(retryAfterDelay) {
 
   this._retryAfterAttempt = this._retryAfterAttempt ? this._retryAfterAttempt++ : 1;
 
-  // CURRENT:  max(retryAfter, random_between(0, min(cap, retryAfter + base * attempt)))
-  // SHOULD BE ? max(retryAfter, random_between(0, min(cap, base * 2 ** attempt)))
+  // retryAfterDelayMs = max(retryAfter, random_between(0, min(cap, base * 2 ** attempt)))
   retryAfterDelayMs = Math.max(retryAfterDelayMs, 
       randomIntFromInterval(0, Math.min(
           this._retryAfterCap, 
-          (this._retryAfterBase * this._retryAfterAttempt))
-          //Math.pow(this._retryAfterBase, this._retryAfterAttempt))
+          Math.pow(this._retryAfterBase, this._retryAfterAttempt))
       )
   );
   

--- a/lib/protocol/stream.js
+++ b/lib/protocol/stream.js
@@ -112,10 +112,15 @@ Stream.prototype._onHeaders = function _onHeaders(frame) {
   if (frame.priority !== undefined) {
     this.priority(frame.priority, true);
   }
-  if (this.state === 'HALF_CLOSED_LOCAL') // transitioned just before this
-  {
+
+  // transitioned just before this
+  if (
+      this.state === 'HALF_CLOSED_LOCAL' || 
+        this.state === 'OPEN'
+  ) {
       this.contentEncoding = frame.headers['content-encoding'];
   }
+
   this.emit('headers', frame.headers);
 };
 
@@ -285,8 +290,7 @@ Stream.prototype._receive = function _receive(frame, ready) {
       {
         var self = this;
         this.pakoInf = new pako.Inflate();
-        this.pakoInf.onData = function(data)
-        {
+        this.pakoInf.onData = function(data) {
             var moreNeeded = self.push(Buffer.from(data));
             if (!moreNeeded)
             {

--- a/test/http.js
+++ b/test/http.js
@@ -326,7 +326,7 @@ describe('http.js', function() {
           });
       }).timeout(10000);
 
-      xit('does a request and gets a response with `retry-after` header and statusCode 503 with gzip encoding', function (done) {
+      it('does a request and gets a response with `retry-after` header and statusCode 503 with gzip encoding', function (done) {
           var retryAfterDelay = 5;
           var retryAfterDelayMs = retryAfterDelay * 1000;
           var restartDate = (Date.now() + retryAfterDelayMs);
@@ -359,7 +359,6 @@ describe('http.js', function() {
                 responseMessage = message;
                 compressedResponseMessage = compressedMessage;
               }
-
 
               var chunk1 = Buffer.from(responseMessage, 0, 15);
               response.write(chunk1);

--- a/test/http.js
+++ b/test/http.js
@@ -482,6 +482,76 @@ describe('http.js', function() {
       });
     }).timeout(10000);
 
+    it('does a request and gets a response statusCode 200 with `retry-after` header using date and statusCode 503 using POST', function (done) {
+      var retryAfterDelay = 5;
+      var retryAfterDelayMs = retryAfterDelay * 1000;
+      var restartDate = (Date.now() + retryAfterDelayMs);
+
+      var path = '/retry-later';
+      var errorMessage = 'Service is NOT available';
+      var message = 'Hello Dave I\'m back';
+
+      var server = http2.createServer(serverOptions, function (request, response) {
+        var requestDate = Date.now();
+          expect(request.url).to.equal(path);
+          expect(request.method).to.equal('POST');
+          expect(request.headers["content-type"]).to.equal("text/plain");
+
+          var body = [];
+          request.on('data', function(chunk) {
+            body.push(chunk);
+          }).on('end', function() {
+            // at this point, `body` has the entire request body stored in it as a string
+            expect(Buffer.concat(body).toString()).to.equal(message);
+          });
+
+          // DEBUG:
+          //console.log('request', request.url, requestDate, restartDate, restartDate - requestDate, requestDate < restartDate);
+
+          if (requestDate < restartDate) {
+            response.setHeader('retry-after', new Date(restartDate));
+            response.writeHead(503);
+            response.write(errorMessage);
+            response.end(); 
+          } else {
+            response.writeHead(200);
+            response.write(message);
+            response.end(); 
+          }
+      });
+
+      server.listen(1244, function () {
+          var options = url.parse('https://localhost:1244' + path);
+          options.key = agentOptions.key;
+          options.ca = agentOptions.ca;
+          options.method = 'POST';
+          options.rejectUnauthorized = true;
+          options.headers = {
+            "Content-Type": "text/plain"
+          };
+
+          http2.globalAgent = new http2.Agent({log: util.clientLog});
+          http2.post(options, message, function (response) {
+
+              // DEBUG:
+              //console.log('response', response.statusCode);
+              expect(response.statusCode).to.equal(200);
+              
+              response.on('data', function (data) {
+                  // TODO
+                  expect(data.toString()).to.equal(message);
+              });
+
+              response.on('end',function(){
+                // WHY finished undefined ?
+                //expect(response.finished).to.equal(true);
+                server.close();
+                done();
+              });
+          });
+      });
+    }).timeout(10000);
+
     xit('does a request and gets a response statusCode 200 with `retry-after` header and statusCode 503 with gzip encoding', function (done) {
       var retryAfterDelay = 5;
       //retryAfterDelay = 0;

--- a/test/http.js
+++ b/test/http.js
@@ -112,6 +112,7 @@ describe('http.js', function() {
           var message = 'Hello world';
 
           var compressedMessage = pako.gzip(message);
+
           compressedMessage = Buffer.from(compressedMessage.buffer);
           var server = http2.createServer(serverOptions, function (request, response) {
               expect(request.url).to.equal(path);
@@ -212,186 +213,332 @@ describe('http.js', function() {
 
   describe('should handle retry-after on statusCode 503', function () {
 
-      it('does a request and gets a response with `retry-after` header in seconds and statusCode 503', function (done) {
-          var retryAfterDelay = 5;
-          var retryAfterDelayMs = retryAfterDelay * 1000;
-          var restartDate = (Date.now() + retryAfterDelayMs);
+    it('does a request and gets a response for statusCode 503 without `retry-after` header', function (done) {
+      var path = '/retry-later';
+      var errorMessage = 'Service is NOT available';
 
-          var path = '/retry-later';
-          var errorMessage = 'Service is NOT available';
-          var message = 'Hello Dave I\'m back';
+      var server = http2.createServer(serverOptions, function (request, response) {
+        var requestDate = Date.now();
+          expect(request.url).to.equal(path);
 
-          var server = http2.createServer(serverOptions, function (request, response) {
-            var requestDate = Date.now();
-              expect(request.url).to.equal(path);
+          // DEBUG:
+          //console.log('request', request.url, requestDate, restartDate, requestDate < restartDate);
 
-              // DEBUG:
-              //console.log('request', request.url, requestDate, restartDate, requestDate < restartDate);
+          response.writeHead(503);
+          response.write(errorMessage);
+          response.end(); 
+      });
 
-              if (requestDate <= restartDate) {
-                response.setHeader('retry-after', retryAfterDelay);
-                response.writeHead(503);
-                response.write(errorMessage);
-                response.end(); 
-              } else {
-                response.writeHead(200);
-                response.write(message);
-                response.end(); 
-              }
-          });
+      server.listen(1244, function () {
+          var options = url.parse('https://localhost:1244' + path);
+          options.key = agentOptions.key;
+          options.ca = agentOptions.ca;
+          options.rejectUnauthorized = true;
 
-          server.listen(1244, function () {
-              var options = url.parse('https://localhost:1244' + path);
-              options.key = agentOptions.key;
-              options.ca = agentOptions.ca;
-              options.rejectUnauthorized = true;
-
-              http2.globalAgent = new http2.Agent({log: util.clientLog});
-              http2.get(options, function (response) {
-
-                  // DEBUG:
-                  //console.log('response', response.statusCode);
-                  
-                  expect(response.statusCode).to.equal(200);
-                  
-                  response.on('data', function (data) {
-                      // TODO
-                      expect(data.toString()).to.equal(message);
-                  });
-
-                  response.on('end',function(){
-                    // WHY finished undefined ?
-                    //expect(response.finished).to.equal(true);
-                    server.close();
-                    done();
-                  });
-              });
-          });
-      }).timeout(10000);
-
-      it('does a request and gets a response with `retry-after` header using date and statusCode 503', function (done) {
-          var retryAfterDelay = 5;
-          var retryAfterDelayMs = retryAfterDelay * 1000;
-          var restartDate = (Date.now() + retryAfterDelayMs);
-
-          var path = '/retry-later';
-          var errorMessage = 'Service is NOT available';
-          var message = 'Hello Dave I\'m back';
-
-          var server = http2.createServer(serverOptions, function (request, response) {
-            var requestDate = Date.now();
-              expect(request.url).to.equal(path);
+          http2.globalAgent = new http2.Agent({log: util.clientLog});
+          http2.get(options, function (response) {
 
               // DEBUG:
-              //console.log('request', request.url, requestDate, restartDate, requestDate < restartDate);
+              //console.log('response', response.statusCode);
+              
+              expect(response.statusCode).to.equal(503);
+              
+              response.on('data', function (data) {
+                  // TODO
+                  expect(data.toString()).to.equal(errorMessage);
+              });
 
-              if (requestDate <= restartDate) {
-                response.setHeader('retry-after', new Date(restartDate));
-                response.writeHead(503);
-                response.write(errorMessage);
-                response.end(); 
-              } else {
-                response.writeHead(200);
-                response.write(message);
-                response.end(); 
-              }
-          });
-
-          server.listen(1244, function () {
-              var options = url.parse('https://localhost:1244' + path);
-              options.key = agentOptions.key;
-              options.ca = agentOptions.ca;
-              options.rejectUnauthorized = true;
-
-              http2.globalAgent = new http2.Agent({log: util.clientLog});
-              http2.get(options, function (response) {
-
-                  // DEBUG:
-                  //console.log('response', response.statusCode);
-                  
-                  expect(response.statusCode).to.equal(200);
-                  
-                  response.on('data', function (data) {
-                      // TODO
-                      expect(data.toString()).to.equal(message);
-                  });
-
-                  response.on('end',function(){
-                    // WHY finished undefined ?
-                    //expect(response.finished).to.equal(true);
-                    server.close();
-                    done();
-                  });
+              response.on('end',function(){
+                // WHY finished undefined ?
+                //expect(response.finished).to.equal(true);
+                server.close();
+                done();
               });
           });
-      }).timeout(10000);
+      });
+    });
 
-      it('does a request and gets a response with `retry-after` header and statusCode 503 with gzip encoding', function (done) {
-          var retryAfterDelay = 5;
-          var retryAfterDelayMs = retryAfterDelay * 1000;
-          var restartDate = (Date.now() + retryAfterDelayMs);
+    it('does a request and gets a response for statusCode 503 without `retry-after` header with gzip encoding', function (done) {
+      var path = '/retry-later';
+      var errorMessage = 'Service is NOT available';
 
-          var path = '/retry-later';
-          var errorMessage = 'Service is NOT available';
-          var message = 'Hello Dave I\'m back';
+      var compressedErrorMessage = pako.gzip(errorMessage);
+      compressedErrorMessage = Buffer.from(compressedErrorMessage.buffer);
 
-          var compressedErrorMessage = pako.gzip(errorMessage);
-          compressedErrorMessage = Buffer.from(compressedErrorMessage.buffer);
+      var server = http2.createServer(serverOptions, function (request, response) {
+        var requestDate = Date.now();
+          expect(request.url).to.equal(path);
 
-          var compressedMessage = pako.gzip(message);
-          compressedMessage = Buffer.from(compressedMessage.buffer);
+          // DEBUG:
+          //console.log('request', request.url, requestDate, restartDate, requestDate < restartDate);
+          response.setHeader('content-encoding', 'gzip');
+          response.writeHead(503);
 
-          var server = http2.createServer(serverOptions, function (request, response) {
-            var requestDate = Date.now();
-              expect(request.url).to.equal(path);
-              response.setHeader('content-encoding', 'gzip');
+          var chunk1 = Buffer.from(compressedErrorMessage, 0, 15);
+          response.write(chunk1);
+          response.write(Buffer.from(compressedErrorMessage, 0, 0));
+          var chunk2 = Buffer.from(compressedErrorMessage, 15);
+          response.write(chunk2);
+          response.end();
+
+      });
+
+      server.listen(1244, function () {
+          var options = url.parse('https://localhost:1244' + path);
+          options.key = agentOptions.key;
+          options.ca = agentOptions.ca;
+          options.rejectUnauthorized = true;
+
+          http2.globalAgent = new http2.Agent({log: util.clientLog});
+          http2.get(options, function (response) {
 
               // DEBUG:
-              //console.log('request', request.url, requestDate, restartDate, requestDate < restartDate);
-              var responseMessage, compressedResponseMessage;
-              if (requestDate <= restartDate) {
-                response.setHeader('retry-after', retryAfterDelay);
-                response.writeHead(503);
-                responseMessage = errorMessage;
-                compressedResponseMessage = compressedErrorMessage;
-              } else {
-                response.writeHead(200);
-                responseMessage = message;
-                compressedResponseMessage = compressedMessage;
-              }
+              //console.log('response', response.statusCode);
+              
+              expect(response.statusCode).to.equal(503);
+              
+              response.on('data', function (data) {
+                  // TODO
+                  expect(data.toString()).to.equal(errorMessage);
+              });
 
-              var chunk1 = Buffer.from(responseMessage, 0, 15);
-              response.write(chunk1);
-              response.write(Buffer.from(compressedResponseMessage, 0, 0));
-              var chunk2 = Buffer.from(compressedResponseMessage, 15);
-              response.write(chunk2);
-              response.end();
-          });
-
-          server.listen(1244, function () {
-              var options = url.parse('https://localhost:1244' + path);
-              options.key = agentOptions.key;
-              options.ca = agentOptions.ca;
-              options.rejectUnauthorized = true;
-
-              http2.globalAgent = new http2.Agent({log: util.clientLog});
-              http2.get(options, function (response) {
-
-                  expect(response.statusCode).to.equal(200);
-                  
-                  response.on('data', function (data) {
-                      expect(data.toString()).to.equal(message);
-                  });
-
-                  response.on('end',function(){
-                    // WHY finished undefined ?
-                    //expect(response.finished).to.equal(true);
-                    server.close();
-                    done();
-                  });
+              response.on('end',function(){
+                // WHY finished undefined ?
+                //expect(response.finished).to.equal(true);
+                server.close();
+                done();
               });
           });
-      }).timeout(10000);
+      });
+    });
+
+    it('does a request and gets a response for statusCode 503 with `retry-after` = 0 header', function (done) {
+      var path = '/retry-later';
+      var errorMessage = 'Service is NOT available';
+
+      var server = http2.createServer(serverOptions, function (request, response) {
+        var requestDate = Date.now();
+          expect(request.url).to.equal(path);
+
+          // DEBUG:
+          //console.log('request', request.url, requestDate, restartDate, requestDate < restartDate);
+
+          response.setHeader('retry-after', 0);
+          response.writeHead(503);
+          response.write(errorMessage);
+          response.end(); 
+      });
+
+      server.listen(1244, function () {
+          var options = url.parse('https://localhost:1244' + path);
+          options.key = agentOptions.key;
+          options.ca = agentOptions.ca;
+          options.rejectUnauthorized = true;
+
+          http2.globalAgent = new http2.Agent({log: util.clientLog});
+          http2.get(options, function (response) {
+
+              // DEBUG:
+              //console.log('response', response.statusCode);
+              
+              expect(response.statusCode).to.equal(503);
+              
+              response.on('data', function (data) {
+                  // TODO
+                  expect(data.toString()).to.equal(errorMessage);
+              });
+
+              response.on('end',function(){
+                // WHY finished undefined ?
+                //expect(response.finished).to.equal(true);
+                server.close();
+                done();
+              });
+          });
+      });
+    });
+
+    it('does a request and gets a response statusCode 200 with `retry-after` header in seconds and statusCode 503', function (done) {
+      var retryAfterDelay = 5;
+      var retryAfterDelayMs = retryAfterDelay * 1000;
+      var restartDate = (Date.now() + retryAfterDelayMs);
+
+      var path = '/retry-later';
+      var errorMessage = 'Service is NOT available';
+      var message = 'Hello Dave I\'m back';
+
+      var server = http2.createServer(serverOptions, function (request, response) {
+          var requestDate = Date.now();
+          expect(request.url).to.equal(path);
+
+          // DEBUG:
+          //console.log('request', request.url, requestDate, restartDate, requestDate < restartDate);
+
+          if (requestDate < restartDate) {
+            response.setHeader('retry-after', retryAfterDelay);
+            response.writeHead(503);
+            response.write(errorMessage);
+            response.end(); 
+          } else {
+            response.writeHead(200);
+            response.write(message);
+            response.end(); 
+          }
+      });
+
+      server.listen(1244, function () {
+          var options = url.parse('https://localhost:1244' + path);
+          options.key = agentOptions.key;
+          options.ca = agentOptions.ca;
+          options.rejectUnauthorized = true;
+
+          http2.globalAgent = new http2.Agent({log: util.clientLog});
+          http2.get(options, function (response) {
+
+              // DEBUG:
+              //console.log('response', response.statusCode);
+              
+              expect(response.statusCode).to.equal(200);
+              
+              response.on('data', function (data) {
+                  // TODO
+                  expect(data.toString()).to.equal(message);
+              });
+
+              response.on('end',function(){
+                // WHY finished undefined ?
+                //expect(response.finished).to.equal(true);
+                server.close();
+                done();
+              });
+          });
+      });
+    }).timeout(10000);
+
+    it('does a request and gets a response statusCode 200 with `retry-after` header using date and statusCode 503', function (done) {
+      var retryAfterDelay = 5;
+      var retryAfterDelayMs = retryAfterDelay * 1000;
+      var restartDate = (Date.now() + retryAfterDelayMs);
+
+      var path = '/retry-later';
+      var errorMessage = 'Service is NOT available';
+      var message = 'Hello Dave I\'m back';
+
+      var server = http2.createServer(serverOptions, function (request, response) {
+        var requestDate = Date.now();
+          expect(request.url).to.equal(path);
+
+          // DEBUG:
+          //console.log('request', request.url, requestDate, restartDate, restartDate - requestDate, requestDate < restartDate);
+
+          if (requestDate < restartDate) {
+            response.setHeader('retry-after', new Date(restartDate));
+            response.writeHead(503);
+            response.write(errorMessage);
+            response.end(); 
+          } else {
+            response.writeHead(200);
+            response.write(message);
+            response.end(); 
+          }
+      });
+
+      server.listen(1244, function () {
+          var options = url.parse('https://localhost:1244' + path);
+          options.key = agentOptions.key;
+          options.ca = agentOptions.ca;
+          options.rejectUnauthorized = true;
+
+          http2.globalAgent = new http2.Agent({log: util.clientLog});
+          http2.get(options, function (response) {
+
+              // DEBUG:
+              //console.log('response', response.statusCode);
+              
+              expect(response.statusCode).to.equal(200);
+              
+              response.on('data', function (data) {
+                  // TODO
+                  expect(data.toString()).to.equal(message);
+              });
+
+              response.on('end',function(){
+                // WHY finished undefined ?
+                //expect(response.finished).to.equal(true);
+                server.close();
+                done();
+              });
+          });
+      });
+    }).timeout(10000);
+
+    xit('does a request and gets a response statusCode 200 with `retry-after` header and statusCode 503 with gzip encoding', function (done) {
+      var retryAfterDelay = 5;
+      //retryAfterDelay = 0;
+      var retryAfterDelayMs = retryAfterDelay * 1000;
+      var restartDate = (Date.now() + retryAfterDelayMs);
+
+      var path = '/retry-later';
+      var errorMessage = 'Service is NOT available';
+      var message = 'Hello Dave I\'m back';
+
+      var compressedErrorMessage = pako.gzip(errorMessage);
+      compressedErrorMessage = Buffer.from(compressedErrorMessage.buffer);
+
+      var compressedMessage = pako.gzip(message);
+      compressedMessage = Buffer.from(compressedMessage.buffer);
+
+      var server = http2.createServer(serverOptions, function (request, response) {
+        var requestDate = Date.now();
+          expect(request.url).to.equal(path);
+          response.setHeader('content-encoding', 'gzip');
+
+          // DEBUG:
+          //console.log('request', request.url, requestDate, restartDate, requestDate < restartDate);
+          var responseMessage, compressedResponseMessage;
+          if (requestDate < restartDate) {
+            response.setHeader('retry-after', retryAfterDelay);
+            response.writeHead(503);
+            responseMessage = errorMessage;
+            compressedResponseMessage = compressedErrorMessage;
+          } else {
+            response.writeHead(200);
+            responseMessage = message;
+            compressedResponseMessage = compressedMessage;
+          }
+
+          var chunk1 = Buffer.from(responseMessage, 0, 15);
+          response.write(chunk1);
+          response.write(Buffer.from(compressedResponseMessage, 0, 0));
+          var chunk2 = Buffer.from(compressedResponseMessage, 15);
+          response.write(chunk2);
+          response.end();
+      });
+
+      server.listen(1244, function () {
+          var options = url.parse('https://localhost:1244' + path);
+          options.key = agentOptions.key;
+          options.ca = agentOptions.ca;
+          options.rejectUnauthorized = true;
+
+          http2.globalAgent = new http2.Agent({log: util.clientLog});
+          http2.get(options, function (response) {
+
+              expect(response.statusCode).to.equal(200);
+              
+              response.on('data', function (data) {
+                  expect(data.toString()).to.equal(message);
+              });
+
+              response.on('end',function(){
+                // WHY finished undefined ?
+                //expect(response.finished).to.equal(true);
+                server.close();
+                done();
+              });
+          });
+      });
+    }).timeout(10000);
   });
 
   describe('Agent', function() {

--- a/test/http.js
+++ b/test/http.js
@@ -141,6 +141,53 @@ describe('http.js', function() {
           });
       });
 
+      it('does a request and gets a response with retry-after header and statusCode 503', function (done) {
+          var retryAfterDelay = 10;
+          var path = '/retry-later';
+          var errorMessage = 'Service is NOT available';
+          var message = 'Hello Dave I\'m back';
+          var compressedErrorMessage = pako.gzip(errorMessage);
+          var compressedMessage = pako.gzip(message);
+          compressedMessage = Buffer.from(compressedMessage.buffer);
+          var server = http2.createServer(serverOptions, function (request, response) {
+              expect(request.url).to.equal(path);
+              response.setHeader('content-encoding', 'gzip');
+              response.setHeader('retry-after', retryAfterDelay);
+              response.writeHead(502);
+              response.write(compressedErrorMessage);
+              response.end();
+          });
+
+          server.listen(1244, function () {
+              var options = url.parse('https://localhost:1244' + path);
+              options.key = agentOptions.key;
+              options.ca = agentOptions.ca;
+              options.rejectUnauthorized = true;
+
+              http2.globalAgent = new http2.Agent({log: util.clientLog});
+              http2.get(options, function (response) {
+                
+                  expect(response.getHeader('retry-after')).to.equal(String(retryAfterDelay));
+                  
+                  response.on('data', function (data) {
+                  
+                      // DEBUG
+                      expect(data.toString()).to.equal(errorMessage);
+
+                      // TODO
+                      //expect(data.toString()).to.equal(message);
+                  });
+
+                  response.on('end',function(){
+                    // WHY finished undefined ?
+                    //expect(response.finished).to.equal(true);
+                    server.close();
+                    done();
+                  });
+              });
+          });
+      });
+
       it('does a request and gets a response with gzip encoding for response larger than MAX_PAYLOAD_SIZE', function (done) {
           var path = '/x';
           var message = generateRandAlphaNumStr(4096);
@@ -175,7 +222,7 @@ describe('http.js', function() {
           });
       });
 
-      it('does a request and gets a response with gzip encoding for response larger than MAX_PAYLOAD_SIZE', function (done) {
+      xit('does a request and gets a response with gzip encoding for response larger than MAX_PAYLOAD_SIZE', function (done) {
           var path = '/x';
           var message = generateRandAlphaNumStr(4096 * 10);
           var compressedMessage = pako.gzip(message);

--- a/test/http.js
+++ b/test/http.js
@@ -176,7 +176,7 @@ describe('http.js', function() {
           });
       });
 
-      xit('does a request and gets a response with gzip encoding for response larger than MAX_PAYLOAD_SIZE', function (done) {
+      it('does a request and gets a response with gzip encoding for response larger than MAX_PAYLOAD_SIZE', function (done) {
           var path = '/x';
           // TODO validate this test is not false positive or memory limit
           // use larger than MAX_PAYLOAD_SIZE > 3 make that test fail

--- a/test/http.js
+++ b/test/http.js
@@ -552,7 +552,7 @@ describe('http.js', function() {
       });
     }).timeout(10000);
 
-    xit('does a request and gets a response statusCode 200 with `retry-after` header and statusCode 503 with gzip encoding', function (done) {
+    it('does a request and gets a response statusCode 200 with `retry-after` header and statusCode 503 with gzip encoding', function (done) {
       var retryAfterDelay = 5;
       //retryAfterDelay = 0;
       var retryAfterDelayMs = retryAfterDelay * 1000;

--- a/test/http.js
+++ b/test/http.js
@@ -153,7 +153,7 @@ describe('http.js', function() {
               expect(request.url).to.equal(path);
               response.setHeader('content-encoding', 'gzip');
               response.setHeader('retry-after', retryAfterDelay);
-              response.writeHead(502);
+              response.writeHead(503);
               response.write(compressedErrorMessage);
               response.end();
           });
@@ -166,7 +166,8 @@ describe('http.js', function() {
 
               http2.globalAgent = new http2.Agent({log: util.clientLog});
               http2.get(options, function (response) {
-                
+
+                  expect(response.statusCode).to.equal(503);
                   expect(response.getHeader('retry-after')).to.equal(String(retryAfterDelay));
                   
                   response.on('data', function (data) {


### PR DESCRIPTION
> If a Retry-After header ([RFC2616]) is present in the response, the client SHOULD<6> retry the 
request after waiting the number of seconds indicated by the Retry-After header. Any such value 
represents an estimate of when the server is expected to be able to process the request.
 

# External reference

- https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37
- https://social.msdn.microsoft.com/Forums/ie/fr-FR/81a0c3c3-aee3-4103-9b1c-731910903514/http-error-503-retryafter-header-value-format?forum=os_exchangeprotocols
- https://stackoverflow.com/questions/3764075/retry-after-http-response-header-does-it-affect-anything

# For reviewer

To run only the retry spec
> node_modules/mocha/bin/_mocha  --exit --grep 503

Current retry-after hook location:
- https://github.com/kaazing/http2.js/blob/features/retry-after/lib/http.js#L1398

RetryAfter request:
- https://github.com/kaazing/http2.js/blob/features/retry-after/lib/http.js#L1204

Spec:
- https://github.com/kaazing/http2.js/blob/features/retry-after/test/http.js#L213

# Spec

```
http.js
    should handle retry-after on statusCode 503
      ✓ does a request and gets a response for statusCode 503 without `retry-after` header (54ms)
      ✓ does a request and gets a response for statusCode 503 without `retry-after` header with gzip encoding
      ✓ does a request and gets a response statusCode 200 with `retry-after` = 0 header in seconds and statusCode 503 (129ms)
      ✓ does a request and gets a response statusCode 200 with `retry-after` header in seconds and statusCode 503 (5020ms)
      ✓ does a request and gets a response statusCode 200 with `retry-after` header using date and statusCode 503 (5024ms)
      ✓ does a request and gets a response statusCode 200 with `retry-after` header using date and statusCode 503 using POST (5022ms)
      ✓ does a request and gets a response statusCode 200 with `retry-after` header and statusCode 503 with gzip encoding (5024ms)


  7 passing (20s)
```
